### PR TITLE
fix: switch tools from host to exec cfg

### DIFF
--- a/antlr/antlr2.bzl
+++ b/antlr/antlr2.bzl
@@ -70,7 +70,7 @@ compile.
         "traceTreeParser": attr.bool(default = False, doc = "Have tree walker rules call traceIn/traceOut."),
         "_tool": attr.label(
             executable = True,
-            cfg = "host",
+            cfg = "exec",
             default = Label("@rules_antlr//src/main/java/org/antlr/bazel"),
         ),
     },

--- a/antlr/antlr3.bzl
+++ b/antlr/antlr3.bzl
@@ -159,7 +159,7 @@ dependencies here.
         "Xwatchconversion": attr.bool(default = False, doc = "Don't delete temporary lexers generated from combined grammars."),
         "_tool": attr.label(
             executable = True,
-            cfg = "host",
+            cfg = "exec",
             default = Label("@rules_antlr//src/main/java/org/antlr/bazel"),
         ),
     },

--- a/antlr/antlr4.bzl
+++ b/antlr/antlr4.bzl
@@ -109,7 +109,7 @@ you need to use a different version, you can specify the dependencies here.
         "visitor": attr.bool(default = False, doc = "Generate parse tree visitor."),
         "_tool": attr.label(
             executable = True,
-            cfg = "host",
+            cfg = "exec",
             default = Label("@rules_antlr//src/main/java/org/antlr/bazel"),
         ),
     },


### PR DESCRIPTION
Bazel 7 with --incompatible_disable_starlark_host_transition (which we use by default) is giving the error:

```
ERROR: Traceback (most recent call last):
        File "D:/udu/b/qpawu7hm/external/rules_antlr/antlr/antlr2.bzl", line 71, column 28, in <toplevel>
                "_tool": attr.label(
Error in label: 'cfg = "host"' is deprecated and should no longer be used. Please use 'cfg = "exec"' instead.
```

I'm not sure your plan for accepting PRs into your hoist branch, but if suitable, I would like to contribute as we find issues in our adoption of rules_antlr
