### PR TITLE
Upgrade Stardoc

### DIFF
--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -1,7 +1,6 @@
 workspace(name = "rules_antlr")
 
-load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_jar")
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive", "http_jar")
 
 local_repository(
     name = "examples",
@@ -30,10 +29,13 @@ load("//antlr:repositories.bzl", "rules_antlr_dependencies")
 
 rules_antlr_dependencies(2, 3, 4)
 
-git_repository(
+http_archive(
     name = "io_bazel_stardoc",
-    remote = "https://github.com/bazelbuild/stardoc.git",
-    tag = "0.4.0",
+    sha256 = "dfbc364aaec143df5e6c52faf1f1166775a5b4408243f445f44b661cfdc3134f",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/stardoc/releases/download/0.5.6/stardoc-0.5.6.tar.gz",
+        "https://github.com/bazelbuild/stardoc/releases/download/0.5.6/stardoc-0.5.6.tar.gz",
+    ],
 )
 
 load("@io_bazel_stardoc//:setup.bzl", "stardoc_repositories")


### PR DESCRIPTION
- fetch using `http_archive` instead of `git_repository`
- upgrade stardoc to `0.5.6`, which still loads deps in the same way as `0.4.0`: https://github.com/bazelbuild/stardoc/releases/tag/0.5.6
