### PR TITLE
VSCode: Set `bazel.lsp.command` to `starpls`

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "bazel.lsp.command": "starpls"
+}


### PR DESCRIPTION
As of now, use [`starpls`](https://github.com/withered-magic/starpls) as it's the only LSP currently supporting also Windows. Once [`bazel-lsp`](https://github.com/cameron-martin/bazel-lsp) adds support for Windows, should try it out (see https://github.com/cameron-martin/bazel-lsp/pull/23).

Reference:

- https://github.com/bazelbuild/vscode-bazel#using-a-language-server-experimental
