### PR TITLE
Buildifier Fix: `constant-glob`

### DIFF
--- a/examples/antlr3/Cpp/src/BUILD.bazel
+++ b/examples/antlr3/Cpp/src/BUILD.bazel
@@ -3,7 +3,7 @@ load("@rules_cc//cc:defs.bzl", "cc_library")
 
 antlr(
     name = "generated",
-    srcs = glob(["T.g"]),
+    srcs = ["T.g"],
     language = "Cpp",
     package = "User",
 )

--- a/examples/antlr3/ObjC/src/BUILD.bazel
+++ b/examples/antlr3/ObjC/src/BUILD.bazel
@@ -2,6 +2,6 @@ load("@rules_antlr//antlr:antlr3.bzl", "antlr")
 
 antlr(
     name = "parser",
-    srcs = glob(["SimpleC.g"]),
+    srcs = ["SimpleC.g"],
     language = "ObjC",
 )

--- a/src/it/java/org/antlr/bazel/BUILD.bazel
+++ b/src/it/java/org/antlr/bazel/BUILD.bazel
@@ -17,7 +17,7 @@ java_library(
 java_library(
     name = "antlr2_tests",
     testonly = True,
-    srcs = glob(["Antlr2Test.java"]),
+    srcs = ["Antlr2Test.java"],
     data = [
         "//:srcs",
         "//antlr:srcs",
@@ -47,7 +47,7 @@ java_tests(
 java_library(
     name = "antlr3_tests",
     testonly = True,
-    srcs = glob(["Antlr3Test.java"]),
+    srcs = ["Antlr3Test.java"],
     data = [
         "//:srcs",
         "//antlr:srcs",
@@ -78,7 +78,7 @@ java_tests(
 java_library(
     name = "antlr4_tests",
     testonly = True,
-    srcs = glob(["Antlr4Test.java"]),
+    srcs = ["Antlr4Test.java"],
     data = [
         "//:srcs",
         "//antlr:srcs",
@@ -111,7 +111,7 @@ java_tests(
 java_library(
     name = "repository_tests",
     testonly = True,
-    srcs = glob(["RepositoriesTest.java"]),
+    srcs = ["RepositoriesTest.java"],
     data = [
         "//:srcs",
         "//antlr:srcs",


### PR DESCRIPTION
Addresses https://github.com/bazelbuild/buildtools/blob/main/WARNINGS.md#glob-pattern-has-no-wildcard-