### PR TITLE
Provide a unique output dir per set of source files

### DIFF
--- a/antlr/impl.bzl
+++ b/antlr/impl.bzl
@@ -37,7 +37,7 @@ def antlr(version, ctx, args):
     if output_type == "srcjar":
         # the Java rules are special in that the output is a .jar file
         srcjar = ctx.actions.declare_file(ctx.attr.name + "." + output_type)
-        output_dir = ctx.configuration.bin_dir.path + "/rules_antlr"
+        output_dir = ctx.configuration.bin_dir.path + "/rules_antlr/" + ctx.attr.name
         outputs = [srcjar]
     else:
         # for all other languages we use directories


### PR DESCRIPTION
https://github.com/marcohu/rules_antlr/pull/23#issue-1883653734

> This is an attempt to make multiple rules_antlr invocations work without sandboxing (eg on Windows, where there's no sandbox). Test with `--spawn_strategy=local`.
> 
> Before, the `AntlrRules.java` code would fail, as it'd find generated grammar files without sandboxing it didn't know about.
> Fix this by providing a unique directory per grammar that's being compiled.
> The code that throws the exception is [master/src/main/java/org/antlr/bazel/AntlrRules.java#L619](https://github.com/marcohu/rules_antlr/blob/master/src/main/java/org/antlr/bazel/AntlrRules.java?rgh-link-date=2023-09-06T09%3A49%3A58Z#L619).