### PR TITLE
Use relative paths for the grammar input files

### DIFF
--- a/antlr/antlr3.bzl
+++ b/antlr/antlr3.bzl
@@ -48,7 +48,7 @@ def _args(ctx, output_dir):
     if ctx.attr.nfa:
         args.add("-nfa")
 
-    args.add("-o")
+    args.add("-fo")
     args.add(output_dir)
 
     if ctx.attr.profile:

--- a/antlr/antlr4.bzl
+++ b/antlr/antlr4.bzl
@@ -58,6 +58,7 @@ def _args(ctx, output_dir):
     if ctx.attr.no_visitor:
         args.add("-no-visitor")
 
+    args.add("-Xexact-output-dir")
     args.add("-o")
     args.add(output_dir)
 

--- a/src/main/java/org/antlr/bazel/AntlrRules.java
+++ b/src/main/java/org/antlr/bazel/AntlrRules.java
@@ -376,7 +376,7 @@ public class AntlrRules
 
         for (String grammar : grammars)
         {
-            this.grammars.add(sandbox.resolve(grammar).toString());
+            this.grammars.add(grammar.toString());
         }
 
         return this;


### PR DESCRIPTION
https://github.com/marcohu/rules_antlr/issues/12
https://github.com/marcohu/rules_antlr/pull/15#issue-891519520

> The file paths that are passed to ANTLR end up in the generated output so using absolute paths breaks caching.
> 
> This PR makes it so that the relative paths to the grammar files that we get from Bazel are passed straight through to ANTLR.
> 
> To keep ANTLR from trying to recreate the directory structure containing the grammar files within the output directory I had to add [`-Xexact-output-dir` for ANTLR4](https://github.com/antlr/antlr4/blob/master/doc/tool-options.md?rgh-link-date=2021-05-14T01%3A46%3A06Z#-xexact-output-dir) and [`-fo` for ANTLR3](https://github.com/antlr/antlr3/blob/5c2a916a10139cdb5c7c8851ee592ed9c3b3d4ff/tool/src/main/java/org/antlr/Tool.java#L747). [ANTLR2 doesn't seem to have an equivalent flag](https://github.com/nco/antlr2/blob/4fb7744d244eee46a981930c6bd1fd43dafe3f20/antlr/Tool.java#L335-L346) and doesn't seem to have the same behavior for relative grammar file input paths.
> 
> Fixes #12.
