### PR TITLE
Enable Cache on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     branches:
       - main
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,12 @@ jobs:
           distribution: zulu
           java-version: "11"
 
+      - name: Mount Bazel Cache
+        uses: actions/cache@v3
+        with:
+          path: "~/.cache/bazel"
+          key: bazel
+
       - name: Verify Bazel installation
         run: bazelisk version
 


### PR DESCRIPTION
Attempt to use cache by mounting the default dir `"~/.cache/bazel"`

References:

- https://github.com/actions/cache/pull/575/files
- https://bazel.build/run/build#repository-cache
- https://blog.engflow.com/2024/05/13/the-many-caches-of-bazel/