### PR TITLE
Fix `RepositoriesTest`: fetch `repository_cache` path from Bazel

### DIFF
--- a/src/it/java/org/antlr/bazel/Command.java
+++ b/src/it/java/org/antlr/bazel/Command.java
@@ -8,14 +8,12 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
-
 /**
  * Bazel command for integration testing.
  *
- * @author  Marco Hunsicker
+ * @author Marco Hunsicker
  */
-class Command
-{
+class Command {
     private String target;
     private Path directory;
     private int exitValue = -1;
@@ -24,60 +22,80 @@ class Command
     /**
      * Creates a new Command object.
      *
-     * @param  directory  the working directory.
-     * @param  target     the build target.
+     * @param directory the working directory.
+     * @param target    the build target.
      */
-    public Command(Path directory, String target)
-            {
-                this.target = target;
-                this.directory = directory;
-            }
+    public Command(Path directory, String target) {
+        this.target = target;
+        this.directory = directory;
+    }
 
     /**
      * Returns the process exit value.
      *
-     * @return  the exit value.
+     * @return the exit value.
      */
-    public int exitValue()
-            {
-                return exitValue;
-            }
+    public int exitValue() {
+        return exitValue;
+    }
 
     /**
      * Returns the build output.
      *
-     * @return  the build output.
+     * @return the build output.
      */
-    public String output()
-            {
-                return output;
-            }
+    public String output() {
+        return output;
+    }
 
     /**
      * Builds the specified target.
      */
-    public Command build() throws Exception
-            {
-                Path repositoryCache = Paths
-                        .get(System.getProperty("user.home"))
-                        .resolve(".cache/bazel/_bazel_" + System.getProperty("user.name") + "/cache/repos/v1");
+    public Command build() throws Exception {
+        String repositoryCachePath = getRepositoryCachePath();
 
-                // TODO by default, Bazel 2.0 does not seem to share the repository cache for
-                // tests which causes the dependencies to be downloaded each time, we therefore
-                // try to share it manually
-                Process p = new ProcessBuilder()
-                        .command(
-                                "bazel", "build", "--jobs", "2", "--repository_cache", repositoryCache.toString(), target)
-                        .directory(directory.toFile())
-                        .redirectErrorStream(true)
-                        .start();
+        // TODO by default, Bazel 2.0 does not seem to share the repository cache for
+        // tests which causes the dependencies to be downloaded each time, we therefore
+        // try to share it manually
+        Process p = new ProcessBuilder()
+                .command(
+                        "bazel", "build", "--jobs", "2", "--repository_cache=" + repositoryCachePath, target)
+                .directory(directory.toFile())
+                .redirectErrorStream(true)
+                .start();
 
-                output = new String(p.getInputStream().readAllBytes());
+        output = new String(p.getInputStream().readAllBytes());
 
-                p.waitFor();
+        p.waitFor();
 
-                exitValue = p.exitValue();
+        exitValue = p.exitValue();
 
-                return this;
-            }
+        return this;
+    }
+
+    /**
+     * Gets the repository cache path from Bazel itself.
+     * 
+     * @return The repository cache path
+     * @throws IOException          If an I/O error occurs
+     * @throws InterruptedException If the process is interrupted
+     * @throws RuntimeException     If Bazel returns a non-zero exit code
+     */
+    private String getRepositoryCachePath() throws IOException, InterruptedException {
+        Process infoProcess = new ProcessBuilder()
+                .command("bazel", "info", "repository_cache")
+                .directory(directory.toFile())
+                .redirectErrorStream(true)
+                .start();
+
+        String path = new String(infoProcess.getInputStream().readAllBytes()).trim();
+        int exitCode = infoProcess.waitFor();
+
+        if (exitCode != 0) {
+            throw new RuntimeException(
+                    "Failed to get repository cache path from Bazel: exit code " + exitCode);
+        }
+
+        return path;
+    }
 }


### PR DESCRIPTION
Currently `Command.build()` passes a `--repository_cache` flag. The comment from the original author @marcohu says:

```java
// TODO by default, Bazel 2.0 does not seem to share the repository cache for
// tests which causes the dependencies to be downloaded each time, we therefore
// try to share it manually
Process p = new ProcessBuilder()
        .command(
                "bazel", "build", "--jobs", "2", "--repository_cache", repositoryCache.toString(), target)
        .directory(directory.toFile())
        .redirectErrorStream(true)
        .start();
```

Bazel should no longer be downloading the dependencies all the time.

The main problem, however, sits on the current implementation to get the repository cache:

```java
Path repositoryCache = Paths
                        .get(System.getProperty("user.home"))
                        .resolve(".cache/bazel/_bazel_" + System.getProperty("user.name") + "/cache/repos/v1");
```

It does not take into consideration `.bazelrc` flags and the default for other systems such as macOS. 

Because of that the `RepositoriesTest` test was failing with the stack trace:

```java
exec ${PAGER:-/usr/bin/less} "$0" || exit 1
Executing tests from //src/it/java/org/antlr/bazel:RepositoriesTest
-----------------------------------------------------------------------------
JUnit4 Test Runner
..E......
Time: 4.824
There was 1 failure:
1) alwaysLoadJavaDependencies(org.antlr.bazel.RepositoriesTest)
java.lang.AssertionError: $TEST_TMPDIR defined: output root default is '/private/var/tmp/_bazel_albertocavalcante/2e86ca776da68f66f9af23762b57a9d6/sandbox/darwin-sandbox/14/execroot/rules_antlr/_tmp/b4490ff28c8587a37881e08b9a790417' and max_idle_secs default is '15'.
Loading: 
Loading: 0 packages loaded
Analyzing: 5 targets (2 packages loaded, 0 targets configured)
INFO: Repository rules_java instantiated at:
  /DEFAULT.WORKSPACE.SUFFIX:429:6: in <toplevel>
  /private/var/tmp/_bazel_albertocavalcante/2e86ca776da68f66f9af23762b57a9d6/sandbox/darwin-sandbox/14/execroot/rules_antlr/_tmp/b4490ff28c8587a37881e08b9a790417/_bazel_albertocavalcante/0e5f54aee768822955796badb9a328f7/external/bazel_tools/tools/build_defs/repo/utils.bzl:233:18: in maybe
Repository rule http_archive defined at:
  /private/var/tmp/_bazel_albertocavalcante/2e86ca776da68f66f9af23762b57a9d6/sandbox/darwin-sandbox/14/execroot/rules_antlr/_tmp/b4490ff28c8587a37881e08b9a790417/_bazel_albertocavalcante/0e5f54aee768822955796badb9a328f7/external/bazel_tools/tools/build_defs/repo/http.bzl:355:31: in <toplevel>
ERROR: An error occurred during the fetch of repository 'rules_java':
   Traceback (most recent call last):
	File "/private/var/tmp/_bazel_albertocavalcante/2e86ca776da68f66f9af23762b57a9d6/sandbox/darwin-sandbox/14/execroot/rules_antlr/_tmp/b4490ff28c8587a37881e08b9a790417/_bazel_albertocavalcante/0e5f54aee768822955796badb9a328f7/external/bazel_tools/tools/build_defs/repo/http.bzl", line 125, column 45, in _http_archive_impl
		download_info = ctx.download_and_extract(
Error in download_and_extract: com.google.devtools.build.lib.unix.FilePermissionException: /Users/albertocavalcante/.cache/bazel/_bazel_albertocavalcante/cache/repos/v1/content_addressable/sha256 (Operation not permitted)
ERROR: /DEFAULT.WORKSPACE.SUFFIX:429:6: fetching http_archive rule //external:rules_java: Traceback (most recent call last):
	File "/private/var/tmp/_bazel_albertocavalcante/2e86ca776da68f66f9af23762b57a9d6/sandbox/darwin-sandbox/14/execroot/rules_antlr/_tmp/b4490ff28c8587a37881e08b9a790417/_bazel_albertocavalcante/0e5f54aee768822955796badb9a328f7/external/bazel_tools/tools/build_defs/repo/http.bzl", line 125, column 45, in _http_archive_impl
		download_info = ctx.download_and_extract(
Error in download_and_extract: com.google.devtools.build.lib.unix.FilePermissionException: /Users/albertocavalcante/.cache/bazel/_bazel_albertocavalcante/cache/repos/v1/content_addressable/sha256 (Operation not permitted)
INFO: Repository antlr2 instantiated at:
  /private/var/tmp/_bazel_albertocavalcante/2e86ca776da68f66f9af23762b57a9d6/sandbox/darwin-sandbox/14/execroot/rules_antlr/bazel-out/darwin_arm64-fastbuild/bin/src/it/java/org/antlr/bazel/RepositoriesTest.runfiles/rules_antlr/external/examples/WORKSPACE.bazel:7:25: in <toplevel>
  /private/var/tmp/_bazel_albertocavalcante/2e86ca776da68f66f9af23762b57a9d6/sandbox/darwin-sandbox/14/execroot/rules_antlr/_tmp/b4490ff28c8587a37881e08b9a790417/_bazel_albertocavalcante/0e5f54aee768822955796badb9a328f7/external/rules_antlr/antlr/repositories.bzl:191:39: in rules_antlr_dependencies
  /private/var/tmp/_bazel_albertocavalcante/2e86ca776da68f66f9af23762b57a9d6/sandbox/darwin-sandbox/14/execroot/rules_antlr/_tmp/b4490ff28c8587a37881e08b9a790417/_bazel_albertocavalcante/0e5f54aee768822955796badb9a328f7/external/rules_antlr/antlr/repositories.bzl:455:25: in _antlr277_dependencies
  /private/var/tmp/_bazel_albertocavalcante/2e86ca776da68f66f9af23762b57a9d6/sandbox/darwin-sandbox/14/execroot/rules_antlr/_tmp/b4490ff28c8587a37881e08b9a790417/_bazel_albertocavalcante/0e5f54aee768822955796badb9a328f7/external/rules_antlr/antlr/repositories.bzl:464:18: in _antlr2_dependencies
  /private/var/tmp/_bazel_albertocavalcante/2e86ca776da68f66f9af23762b57a9d6/sandbox/darwin-sandbox/14/execroot/rules_antlr/_tmp/b4490ff28c8587a37881e08b9a790417/_bazel_albertocavalcante/0e5f54aee768822955796badb9a328f7/external/rules_antlr/antlr/repositories.bzl:510:18: in _dependencies
  /private/var/tmp/_bazel_albertocavalcante/2e86ca776da68f66f9af23762b57a9d6/sandbox/darwin-sandbox/14/execroot/rules_antlr/_tmp/b4490ff28c8587a37881e08b9a790417/_bazel_albertocavalcante/0e5f54aee768822955796badb9a328f7/external/rules_antlr/antlr/repositories.bzl:517:13: in _download
Repository rule http_jar defined at:
  /private/var/tmp/_bazel_albertocavalcante/2e86ca776da68f66f9af23762b57a9d6/sandbox/darwin-sandbox/14/execroot/rules_antlr/_tmp/b4490ff28c8587a37881e08b9a790417/_bazel_albertocavalcante/0e5f54aee768822955796badb9a328f7/external/bazel_tools/tools/build_defs/repo/http.bzl:492:27: in <toplevel>
ERROR: /private/var/tmp/_bazel_albertocavalcante/2e86ca776da68f66f9af23762b57a9d6/sandbox/darwin-sandbox/14/execroot/rules_antlr/bazel-out/darwin_arm64-fastbuild/bin/src/it/java/org/antlr/bazel/RepositoriesTest.runfiles/rules_antlr/external/examples/antlr2/Cpp/src/main/antlr2/BUILD.bazel:16:6: //antlr2/Cpp/src/main/antlr2:generated depends on @rules_antlr//src/main/java/org/antlr/bazel:bazel in repository @rules_antlr which failed to fetch. no such package '@rules_java//java': com.google.devtools.build.lib.unix.FilePermissionException: /Users/albertocavalcante/.cache/bazel/_bazel_albertocavalcante/cache/repos/v1/content_addressable/sha256 (Operation not permitted)
ERROR: Analysis of target '//antlr2/Cpp/src/main/antlr2:generated' failed; build aborted: Analysis failed
INFO: Elapsed time: 0.957s
INFO: 0 processes.
FAILED: Build did NOT complete successfully (30 packages loaded, 11 targets configured)
FAILED: Build did NOT complete successfully (30 packages loaded, 11 targets configured)
 expected:<0> but was:<1>
	at org.junit.Assert.fail(Assert.java:88)
	at org.junit.Assert.failNotEquals(Assert.java:834)
	at org.junit.Assert.assertEquals(Assert.java:645)
	at org.antlr.bazel.RepositoriesTest.alwaysLoadJavaDependencies(RepositoriesTest.java:189)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at com.google.testing.junit.runner.internal.junit4.CancellableRequestFactory$CancellableRunner.run(CancellableRequestFactory.java:108)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:115)
	at com.google.testing.junit.runner.junit4.JUnit4Runner.run(JUnit4Runner.java:116)
	at com.google.testing.junit.runner.BazelTestRunner.runTestsInSuite(BazelTestRunner.java:148)
	at com.google.testing.junit.runner.BazelTestRunner.main(BazelTestRunner.java:75)

FAILURES!!!
Tests run: 8,  Failures: 1


BazelTestRunner exiting with a return value of 1
JVM shutdown hooks (if any) will run now.
The JVM will exit once they complete.

-- JVM shutdown starting at 2025-03-13 04:34:24 --
```

To fix it for now, the implementation relies on retrieving the location from the output of `bazel info repository_cache`. this of course brings performance downsides but it is more reliable. I will remove this flag in a future PR but wanted to stick with the original author's intent and follow along.


Also formatted source code with:

```sh
bang /Users/albertocavalcante/dev/workspace/rewrite-jbang/rewrite.java --recipes org.openrewrite.java.format.AutoFormat
```
