### PR TITLE
bump `rules_python` to `1.2.0`

### DIFF
--- a/antlr/repositories.bzl
+++ b/antlr/repositories.bzl
@@ -381,8 +381,9 @@ def _load_rules_python_repositories(workspace):
     return "" if workspace.find('load("@rules_python//python:repositories.bzl", "py_repositories")') > -1 else """
 http_archive(
     name = "rules_python",
-    sha256 = "aa96a691d3a8177f3215b14b0edc9641787abaaa30363a080165d06ab65e1161",
-    url = "https://github.com/bazelbuild/rules_python/releases/download/0.0.1/rules_python-0.0.1.tar.gz",
+    sha256 = "2ef40fdcd797e07f0b6abda446d1d84e2d9570d234fddf8fcd2aa262da852d1c",
+    strip_prefix = "rules_python-1.2.0",
+    url = "https://github.com/bazelbuild/rules_python/releases/download/1.2.0/rules_python-1.2.0.tar.gz",
 )
 load("@rules_python//python:repositories.bzl", "py_repositories")
 py_repositories()

--- a/examples/WORKSPACE.bazel
+++ b/examples/WORKSPACE.bazel
@@ -24,6 +24,13 @@ http_archive(
 )
 
 http_archive(
+    name = "proto_bazel_features",
+    sha256 = "091d8b1e1f0bf1f7bd688b95007687e862cc489f8d9bc21c14be5fd032a8362f",
+    strip_prefix = "bazel_features-1.26.0",
+    url = "https://github.com/bazel-contrib/bazel_features/releases/download/v1.26.0/bazel_features-v1.26.0.tar.gz",
+)
+
+http_archive(
     name = "io_bazel_rules_go",
     sha256 = "b78f77458e77162f45b4564d6b20b6f92f56431ed59eaaab09e7819d1d850313",
     urls = [

--- a/examples/WORKSPACE.bazel
+++ b/examples/WORKSPACE.bazel
@@ -30,6 +30,10 @@ http_archive(
     url = "https://github.com/bazel-contrib/bazel_features/releases/download/v1.26.0/bazel_features-v1.26.0.tar.gz",
 )
 
+load("@proto_bazel_features//:deps.bzl", "bazel_features_deps")
+
+bazel_features_deps()
+
 http_archive(
     name = "io_bazel_rules_go",
     sha256 = "b78f77458e77162f45b4564d6b20b6f92f56431ed59eaaab09e7819d1d850313",

--- a/examples/WORKSPACE.bazel
+++ b/examples/WORKSPACE.bazel
@@ -33,8 +33,9 @@ go_register_toolchains(version = "1.24.1")
 
 http_archive(
     name = "rules_python",
-    sha256 = "aa96a691d3a8177f3215b14b0edc9641787abaaa30363a080165d06ab65e1161",
-    url = "https://github.com/bazelbuild/rules_python/releases/download/0.0.1/rules_python-0.0.1.tar.gz",
+    sha256 = "2ef40fdcd797e07f0b6abda446d1d84e2d9570d234fddf8fcd2aa262da852d1c",
+    strip_prefix = "rules_python-1.2.0",
+    url = "https://github.com/bazelbuild/rules_python/releases/download/1.2.0/rules_python-1.2.0.tar.gz",
 )
 
 load("@rules_python//python:repositories.bzl", "py_repositories")

--- a/examples/WORKSPACE.bazel
+++ b/examples/WORKSPACE.bazel
@@ -17,6 +17,13 @@ http_archive(
 )
 
 http_archive(
+    name = "rules_cc",
+    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.1.1/rules_cc-0.1.1.tar.gz"],
+    sha256 = "712d77868b3152dd618c4d64faaddefcc5965f90f5de6e6dd1d5ddcd0be82d42",
+    strip_prefix = "rules_cc-0.1.1",
+)
+
+http_archive(
     name = "io_bazel_rules_go",
     sha256 = "b78f77458e77162f45b4564d6b20b6f92f56431ed59eaaab09e7819d1d850313",
     urls = [

--- a/src/it/java/org/antlr/bazel/TestWorkspace.java
+++ b/src/it/java/org/antlr/bazel/TestWorkspace.java
@@ -76,8 +76,9 @@ class TestWorkspace
                     + "go_register_toolchains(version = \"1.24.1\")\n"
                                 + "http_archive(\n"
                                 + "    name = \"rules_python\",\n"
-                                + "    sha256 = \"aa96a691d3a8177f3215b14b0edc9641787abaaa30363a080165d06ab65e1161\",\n"
-                                + "    url = \"https://github.com/bazelbuild/rules_python/releases/download/0.0.1/rules_python-0.0.1.tar.gz\",\n"
+                                + "    sha256 = \"2ef40fdcd797e07f0b6abda446d1d84e2d9570d234fddf8fcd2aa262da852d1c\",\n"
+                                + "    strip_prefix = \"rules_python-1.2.0\",\n"
+                                + "    url = \"https://github.com/bazelbuild/rules_python/releases/download/1.2.0/rules_python-1.2.0.tar.gz\",\n"
                                 + ")\n"
                                 + "load(\"@rules_python//python:repositories.bzl\", \"py_repositories\")\n"
                                 + "py_repositories()\n";


### PR DESCRIPTION
## Troubleshooting

```sh
Unable to find package for @proto_bazel_features//:features.bzl: The repository '@proto_bazel_features' could not be resolved: Repository '@proto_bazel_features' is not defined.
```

`protobuf` imports `bazel_features` as `proto_bazel_features`: https://github.com/protocolbuffers/protobuf/blob/main/MODULE.bazel#L32