### PR TITLE
🐛 fix `RepositoriesTest`: make `alwaysLoadJavaDeps` hermetic

### DIFF
--- a/src/it/java/org/antlr/bazel/Command.java
+++ b/src/it/java/org/antlr/bazel/Command.java
@@ -7,6 +7,9 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 /**
  * Bazel command for integration testing.
@@ -50,11 +53,38 @@ class Command {
 
     /**
      * Builds the specified target.
+     * 
+     * @return this Command instance.
+     * @throws Exception if an error occurs.
      */
     public Command build() throws Exception {
+        return build(new String[0]);
+    }
+
+    /**
+     * Builds the specified target with additional flags.
+     * 
+     * @param flags Additional flags to pass to the bazel build command.
+     * @return this Command instance.
+     * @throws Exception if an error occurs.
+     */
+    public Command build(String... flags) throws Exception {
+        List<String> command = new ArrayList<>();
+        command.add("bazel");
+        command.add("build");
+        command.add("--jobs");
+        command.add("2");
+        
+        // Add any additional flags
+        if (flags != null && flags.length > 0) {
+            command.addAll(Arrays.asList(flags));
+        }
+        
+        // Add the target at the end
+        command.add(target);
+
         Process p = new ProcessBuilder()
-                .command(
-                        "bazel", "build", "--jobs", "2", target)
+                .command(command)
                 .directory(directory.toFile())
                 .redirectErrorStream(true)
                 .start();

--- a/src/it/java/org/antlr/bazel/RepositoriesTest.java
+++ b/src/it/java/org/antlr/bazel/RepositoriesTest.java
@@ -185,7 +185,7 @@ public class RepositoriesTest
 
                 TestWorkspace workspace = new TestWorkspace(true);
                 workspace.file("WORKSPACE.bazel", contents);
-                Command c = new Command(workspace.root, "//antlr2/Cpp/...").build();
+                Command c = new Command(workspace.root, "//antlr2/Cpp/...").build("--java_runtime_version=remotejdk_11");
                 assertEquals(c.output(), 0, c.exitValue());
             }
 }


### PR DESCRIPTION
Fix the error below

```java
ERROR: /home/default/.cache/bazel/_bazel_default/ae5704ece99183cca34dee01a273e39d/sandbox/processwrapper-sandbox/98/execroot/rules_antlr/_tmp/d46b106866eda0d779f256020904cd30/_bazel_default/7b30a86ffd824579a30720ca614773c6/external/local_jdk/BUILD.bazel:2:10: in fail_rule rule @local_jdk//:jdk: 
Traceback (most recent call last):
	File "/home/default/.cache/bazel/_bazel_default/ae5704ece99183cca34dee01a273e39d/sandbox/processwrapper-sandbox/98/execroot/rules_antlr/_tmp/d46b106866eda0d779f256020904cd30/_bazel_default/7b30a86ffd824579a30720ca614773c6/external/bazel_tools/tools/jdk/fail_rule.bzl", line 19, column 13, in _fail_rule_impl
		fail("%s %s" % (ctx.attr.header, ctx.attr.message))
Error in fail: Auto-Configuration Error: Cannot find Java binary bin/java in /home/default/.cache/bazel/_bazel_default/ae5704ece99183cca34dee01a273e39d/sandbox/processwrapper-sandbox/98/execroot/rules_antlr/_tmp/d46b106866eda0d779f256020904cd30/_bazel_default/install/bbf286e15fff7eb9e40ed42b3c5965d3/embedded_tools/tools/jdk/nosystemjdk; either correct your JAVA_HOME, PATH or specify Java from remote repository (e.g. --java_runtime_version=remotejdk_11
ERROR: /home/default/.cache/bazel/_bazel_default/ae5704ece99183cca34dee01a273e39d/sandbox/processwrapper-sandbox/98/execroot/rules_antlr/_tmp/d46b106866eda0d779f256020904cd30/_bazel_default/7b30a86ffd824579a30720ca614773c6/external/local_jdk/BUILD.bazel:2:10: Analysis of target '@local_jdk//:jdk' failed
INFO: Repository remotejdk11_linux_aarch64 instantiated at:
  /DEFAULT.WORKSPACE.SUFFIX:62:6: in <toplevel>
  /home/default/.cache/bazel/_bazel_default/ae5704ece99183cca34dee01a273e39d/sandbox/processwrapper-sandbox/98/execroot/rules_antlr/_tmp/d46b106866eda0d779f256020904cd30/_bazel_default/7b30a86ffd824579a30720ca614773c6/external/bazel_tools/tools/build_defs/repo/utils.bzl:233:18: in maybe
  /home/default/.cache/bazel/_bazel_default/ae5704ece99183cca34dee01a273e39d/sandbox/processwrapper-sandbox/98/execroot/rules_antlr/_tmp/d46b106866eda0d779f256020904cd30/_bazel_default/7b30a86ffd824579a30720ca614773c6/external/bazel_tools/tools/jdk/remote_java_repository.bzl:49:17: in remote_java_repository
Repository rule http_archive defined at:
  /home/default/.cache/bazel/_bazel_default/ae5704ece99183cca34dee01a273e39d/sandbox/processwrapper-sandbox/98/execroot/rules_antlr/_tmp/d46b106866eda0d779f256020904cd30/_bazel_default/7b30a86ffd824579a30720ca614773c6/external/bazel_tools/tools/build_defs/repo/http.bzl:372:31: in <toplevel>
ERROR: /home/default/.cache/bazel/_bazel_default/ae5704ece99183cca34dee01a273e39d/sandbox/processwrapper-sandbox/98/execroot/rules_antlr/_tmp/d46b106866eda0d779f256020904cd30/_bazel_default/7b30a86ffd824579a30720ca614773c6/external/bazel_tools/tools/jdk/BUILD:58:19: errors encountered resolving toolchains for @bazel_tools//tools/jdk:current_java_runtime
ERROR: Analysis of target '//antlr2/Cpp/src/main/cpp:bin' failed; build aborted: 
INFO: Elapsed time: 13.808s
INFO: 0 processes.
FAILED: Build did NOT complete successfully (45 packages loaded, 372 targets configured)
 expected:<0> but was:<1>
	at org.junit.Assert.fail(Assert.java:88)
	at org.junit.Assert.failNotEquals(Assert.java:834)
	at org.junit.Assert.assertEquals(Assert.java:645)
	at org.antlr.bazel.RepositoriesTest.alwaysLoadJavaDependencies(RepositoriesTest.java:189)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at com.google.testing.junit.runner.internal.junit4.CancellableRequestFactory$CancellableRunner.run(CancellableRequestFactory.java:108)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:115)
	at com.google.testing.junit.runner.junit4.JUnit4Runner.run(JUnit4Runner.java:116)
	at com.google.testing.junit.runner.BazelTestRunner.runTestsInSuite(BazelTestRunner.java:145)
	at com.google.testing.junit.runner.BazelTestRunner.main(BazelTestRunner.java:76)

FAILURES!!!
Tests run: 8,  Failures: 1
```