### PR TITLE
Fix Python glob and extension names

### DIFF
--- a/antlr/impl.bzl
+++ b/antlr/impl.bzl
@@ -109,7 +109,7 @@ def extension(language):
     if language == OBJC:
         return ".objc"
     if language == PYTHON or language == PYTHON2 or language == PYTHON3:
-        return ".py"
+        return "_py"
     return ""
 
 def lib_dir(imports):

--- a/antlr/repositories.bzl
+++ b/antlr/repositories.bzl
@@ -407,7 +407,7 @@ go_library(
         script += _load_rules_python_defs(script) + """
 py_library(
     name = "python2",
-    srcs = glob(["runtime/Python3/src/*.py"], allow_empty = True),
+    srcs = glob(["runtime/Python3/src/**/*.py"], allow_empty = True),
     imports = ["runtime/Python3/src"],
     visibility = ["//visibility:public"],
 )
@@ -418,7 +418,7 @@ py_library(
         script += _load_rules_python_defs(script) + """
 py_library(
     name = "python",
-    srcs = glob(["runtime/Python3/src/*.py"], allow_empty = True),
+    srcs = glob(["runtime/Python3/src/**/*.py"], allow_empty = True),
     imports = ["runtime/Python3/src"],
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
We have these two patches internally for a long time and are soon looking into Bzlmod support for rules_antlr. It would be nice to get the patches in before that :)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Updated Python file naming to adopt a revised extension format.
  - Enhanced file discovery by expanding search patterns to include files from nested directories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->