### PR TITLE
chore(ci): fix workflow run 3rd party contributors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,6 +103,18 @@ jobs:
           ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || '' }}
           persist-credentials: false
 
+      # Combined safety check for pull_request_target and unauthorized PRs
+      - name: Safety check for PR code
+        if: github.event_name == 'pull_request_target' && needs.check_authorization.outputs.is_authorized != 'true'
+        run: |
+          # Check if the workflow file itself was modified in the PR
+          if git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} | grep -q "\.github/workflows/"; then
+            echo "::error::PR contains workflow file changes but is not authorized"
+            echo "These files were modified:"
+            git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} | grep "\.github/workflows/"
+            exit 1
+          fi
+
       - name: Set up JDK 11
         uses: actions/setup-java@3a4f6e1af504cf6a31855fa899c6aa5355ba6c12 # v4.7.0
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,6 +141,7 @@ jobs:
         shell: bash
         run: |
           cd examples
+          echo -e "\033[1;34m🔨 Building examples...\033[0m"
           bazelisk build \
             --config ci \
             --config remote-cache \
@@ -162,6 +163,7 @@ jobs:
         shell: bash
         run: |
           cd examples/antlr4-opt
+          echo -e "\033[1;34m🔨 Building antlr4-opt...\033[0m"
           bazelisk build \
             --config ci \
             --config remote-cache \
@@ -171,6 +173,7 @@ jobs:
       - name: Run tests
         shell: bash
         run: |
+          echo -e "\033[1;34m🧪 Running tests...\033[0m"
           bazelisk test \
             --config ci \
             --config remote-cache \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,10 @@ jobs:
 
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          # For pull_request_target events, we need to check out the PR code
+          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || '' }}
+          persist-credentials: false
 
       - name: Set up JDK 11
         uses: actions/setup-java@3a4f6e1af504cf6a31855fa899c6aa5355ba6c12 # v4.7.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,50 +30,61 @@ jobs:
     timeout-minutes: 5
     permissions:
       contents: read
-      pull-requests: read # Needed to check PR labels
+      pull-requests: read  # Only needed to check PR labels
 
     outputs:
       is_authorized: ${{ steps.check.outputs.is_authorized }}
-
+      
     steps:
       - name: Check authorization
         id: check
+        shell: bash
         run: |
-          # For push to main or workflow_dispatch, always authorize
-          if [[ "${{ github.event_name }}" == "push" || "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            echo "is_authorized=true" >> $GITHUB_OUTPUT
-            echo "Authorized: push or workflow_dispatch event"
-            exit 0
-          fi
-
-          # For PRs, check various authorization criteria
-          if [[ "${{ github.event_name }}" == "pull_request_target" ]]; then
-            # Auto-authorize if PR is from the repository owner
+          # Enable terminal colors
+          export TERM=xterm-256color
+          
+          # Initialize as unauthorized
+          AUTHORIZED="false"
+          REASON=""
+          
+          # Determine authorization based on event type and conditions
+          if [[ "${{ github.event_name }}" == "push" ]]; then
+            AUTHORIZED="true"
+            REASON="Push to main branch"
+          elif [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            AUTHORIZED="true"
+            REASON="Manual workflow trigger"
+          elif [[ "${{ github.event_name }}" == "pull_request_target" ]]; then
+            # Check owner
             if [[ "${{ github.event.pull_request.head.repo.owner.login }}" == "${{ github.repository_owner }}" ]]; then
-              echo "is_authorized=true" >> $GITHUB_OUTPUT
-              echo "Authorized: PR from repository owner"
-              exit 0
+              AUTHORIZED="true"
+              REASON="PR from repository owner"
+            # Check association
+            elif [[ "${{ github.event.pull_request.author_association }}" == "OWNER" || 
+                    "${{ github.event.pull_request.author_association }}" == "MEMBER" || 
+                    "${{ github.event.pull_request.author_association }}" == "COLLABORATOR" ]]; then
+              AUTHORIZED="true"
+              REASON="PR from repository member/collaborator"
+            # Check for authorization label
+            elif [[ "${{ contains(github.event.pull_request.labels.*.name, 'authorized-secrets') }}" == "true" ]]; then
+              AUTHORIZED="true"
+              REASON="PR marked with authorized-secrets label"
+            else
+              REASON="PR from external contributor without authorization"
             fi
-            
-            # Auto-authorize if PR is from a repository member/collaborator
-            if [[ "${{ github.event.pull_request.author_association }}" == "OWNER" || 
-                  "${{ github.event.pull_request.author_association }}" == "MEMBER" || 
-                  "${{ github.event.pull_request.author_association }}" == "COLLABORATOR" ]]; then
-              echo "is_authorized=true" >> $GITHUB_OUTPUT
-              echo "Authorized: PR from repository member/collaborator"
-              exit 0
+          fi
+          
+          # Set output
+          echo "is_authorized=$AUTHORIZED" >> $GITHUB_OUTPUT
+          
+          # Log with colors
+          if [[ "$AUTHORIZED" == "true" ]]; then
+            echo -e "\033[1;32m✅ AUTHORIZED: $REASON\033[0m"
+          else
+            echo -e "\033[1;33m⚠️ NOT AUTHORIZED: $REASON\033[0m"
+            if [[ "${{ github.event_name }}" == "pull_request_target" ]]; then
+              echo -e "\033[0;36mℹ️ External contributors need the 'authorized-secrets' label to access secrets\033[0m"
             fi
-            
-            # Check for the authorized-secrets label for external contributors
-            if [[ "${{ contains(github.event.pull_request.labels.*.name, 'authorized-secrets') }}" == "true" ]]; then
-              echo "is_authorized=true" >> $GITHUB_OUTPUT
-              echo "Authorized: PR with authorized-secrets label"
-              exit 0
-            fi
-            
-            # Not authorized
-            echo "is_authorized=false" >> $GITHUB_OUTPUT
-            echo "Not authorized: PR from external contributor without proper authorization"
           fi
   
   build:
@@ -88,17 +99,30 @@ jobs:
     environment: ${{ needs.authorize.outputs.is_authorized == 'true' && 'secrets-enabled' || 'no-secrets' }}
     
     env:
-      BUILDBUDDY_API_KEY: ${{ needs.check_authorization.outputs.is_authorized == 'true' && secrets.BUILDBUDDY_API_KEY || 'dummy-value-for-unauthorized-builds' }}
-
+      # Enable colors in logs
+      TERM: xterm-256color
+      FORCE_COLOR: "true"
+      # API key access based on authorization
+      BUILDBUDDY_API_KEY: ${{ needs.authorize.outputs.is_authorized == 'true' && secrets.BUILDBUDDY_API_KEY || 'dummy-value-for-unauthorized-prs' }}
+      
     steps:
       - name: Log security context
+        shell: bash
         run: |
-          echo "Event type: ${{ github.event_name }}"
-          echo "Is authorized: ${{ needs.check_authorization.outputs.is_authorized }}"
-          if [ "${{ env.BUILDBUDDY_API_KEY }}" == "dummy-value-for-unauthorized-builds" ]; then
-            echo "Using dummy API key (secrets not available)"
+          echo -e "\033[1;34m🔍 WORKFLOW CONTEXT\033[0m"
+          echo -e "  Event type: \033[1m${{ github.event_name }}\033[0m"
+          if [[ "${{ github.event_name }}" == "pull_request_target" ]]; then
+            echo -e "  PR #: \033[1m${{ github.event.pull_request.number }}\033[0m"
+            echo -e "  PR Author: \033[1m${{ github.event.pull_request.user.login }}\033[0m"
+            echo -e "  Author association: \033[1m${{ github.event.pull_request.author_association }}\033[0m"
+          fi
+          
+          echo ""
+          echo -e "\033[1;34m🔐 SECURITY STATUS\033[0m"
+          if [[ "${{ needs.authorize.outputs.is_authorized }}" == "true" ]]; then
+            echo -e "  \033[1;32m✅ AUTHORIZED: Using real API key\033[0m"
           else
-            echo "Using real API key (secrets available)"
+            echo -e "  \033[1;33m⚠️ UNAUTHORIZED: Using dummy API key (limited functionality)\033[0m"
           fi
 
       - name: Checkout repository

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
             echo "is_authorized=false" >> $GITHUB_OUTPUT
             echo "Not authorized: PR from external contributor without proper authorization"
           fi
-
+  
   build:
     name: "Build and Test"
     needs: authorize
@@ -83,9 +83,10 @@ jobs:
     timeout-minutes: 60
     permissions:
       contents: read
-
-    environment: ${{ needs.check_authorization.outputs.is_authorized == 'true' && 'production' || 'no-secrets' }}
-
+    
+    # Use environment to control secrets access
+    environment: ${{ needs.authorize.outputs.is_authorized == 'true' && 'secrets-enabled' || 'no-secrets' }}
+    
     env:
       BUILDBUDDY_API_KEY: ${{ needs.check_authorization.outputs.is_authorized == 'true' && secrets.BUILDBUDDY_API_KEY || 'dummy-value-for-unauthorized-builds' }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
       - "docs/**"
       - "LICENSE"
       - ".github/*.md"
-  pull_request:
+  pull_request_target:
     branches:
       - main
     paths-ignore:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,7 +131,7 @@ jobs:
           bazelisk build \
             --config ci \
             --config remote-cache \
-            --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_API_KEY }} \
+            --remote_header=x-buildbuddy-api-key=${{ env.BUILDBUDDY_API_KEY }} \
             //antlr2/Cpp/... \
             //antlr2/Calc/... \
             //antlr2/Python/... \
@@ -152,7 +152,7 @@ jobs:
           bazelisk build \
             --config ci \
             --config remote-cache \
-            --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_API_KEY }} \
+            --remote_header=x-buildbuddy-api-key=${{ env.BUILDBUDDY_API_KEY }} \
             //...
 
       - name: Run tests
@@ -161,7 +161,7 @@ jobs:
           bazelisk test \
             --config ci \
             --config remote-cache \
-            --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_API_KEY }} \
+            --remote_header=x-buildbuddy-api-key=${{ env.BUILDBUDDY_API_KEY }} \
             //...
 
       - name: Shutdown Bazel

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,7 @@ jobs:
   build:
     needs: check_authorization
     runs-on: ubuntu-20.04
+    timeout-minutes: 60
     permissions:
       contents: read
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,18 +108,26 @@ jobs:
           ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || '' }}
           persist-credentials: false
 
-      # Combined safety check for pull_request_target and unauthorized PRs
-      - name: Safety check for PR code
-        if: github.event_name == 'pull_request_target' && needs.check_authorization.outputs.is_authorized != 'true'
+      # Security check for workflow file modifications in PRs
+      - name: Validate PR content
+        if: github.event_name == 'pull_request_target'
+        shell: bash
         run: |
-          # Check if the workflow file itself was modified in the PR
-          if git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} | grep -q "\.github/workflows/"; then
-            echo "::error::PR contains workflow file changes but is not authorized"
-            echo "These files were modified:"
-            git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} | grep "\.github/workflows/"
-            exit 1
+          # Check for workflow file modifications
+          MODIFIED_WORKFLOWS=$(git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} | grep -E "\.github/workflows/.*\.yml$" || true)
+          
+          if [[ -n "$MODIFIED_WORKFLOWS" ]]; then
+            echo -e "\033[1;33m⚠️ PR modifies workflow files:\033[0m"
+            echo -e "\033[0;36m$MODIFIED_WORKFLOWS\033[0m"
+            
+            # Fail if unauthorized PR modifies workflow files
+            if [[ "${{ needs.authorize.outputs.is_authorized }}" != "true" ]]; then
+              echo -e "\033[1;31m❌ ERROR: Unauthorized PR cannot modify workflow files\033[0m"
+              echo -e "\033[0;36mℹ️ Contributors must be repository members or have the 'authorized-secrets' label\033[0m"
+              exit 1
+            fi
           fi
-
+      
       - name: Set up JDK 11
         uses: actions/setup-java@3a4f6e1af504cf6a31855fa899c6aa5355ba6c12 # v4.7.0
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  check_authorization:
+  authorize:
+    name: "Authorization Check"
     runs-on: ubuntu-20.04
     timeout-minutes: 5
     permissions:
@@ -76,7 +77,8 @@ jobs:
           fi
 
   build:
-    needs: check_authorization
+    name: "Build and Test"
+    needs: authorize
     runs-on: ubuntu-20.04
     timeout-minutes: 60
     permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,14 @@ jobs:
   build:
     needs: check_authorization
     runs-on: ubuntu-20.04
-
+    permissions:
+      contents: read
+    
+    environment: ${{ needs.check_authorization.outputs.is_authorized == 'true' && 'production' || 'no-secrets' }}
+    
+    env:
+      BUILDBUDDY_API_KEY: ${{ needs.check_authorization.outputs.is_authorized == 'true' && secrets.BUILDBUDDY_API_KEY || 'dummy-value-for-unauthorized-builds' }}
+      
     steps:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,16 @@ jobs:
       BUILDBUDDY_API_KEY: ${{ needs.check_authorization.outputs.is_authorized == 'true' && secrets.BUILDBUDDY_API_KEY || 'dummy-value-for-unauthorized-builds' }}
       
     steps:
+      - name: Log security context
+        run: |
+          echo "Event type: ${{ github.event_name }}"
+          echo "Is authorized: ${{ needs.check_authorization.outputs.is_authorized }}"
+          if [ "${{ env.BUILDBUDDY_API_KEY }}" == "dummy-value-for-unauthorized-builds" ]; then
+            echo "Using dummy API key (secrets not available)"
+          else
+            echo "Using real API key (secrets available)"
+          fi
+
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,7 @@ jobs:
           fi
 
   build:
+    needs: check_authorization
     runs-on: ubuntu-20.04
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ concurrency:
 jobs:
   check_authorization:
     runs-on: ubuntu-20.04
+    timeout-minutes: 5
     permissions:
       contents: read
       pull-requests: read # Needed to check PR labels

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-20.04
     permissions:
       contents: read
-      pull-requests: read  # Needed to check PR labels
+      pull-requests: read # Needed to check PR labels
 
     outputs:
       is_authorized: ${{ steps.check.outputs.is_authorized }}
@@ -43,7 +43,7 @@ jobs:
             echo "Authorized: push or workflow_dispatch event"
             exit 0
           fi
-          
+
           # For PRs, check various authorization criteria
           if [[ "${{ github.event_name }}" == "pull_request_target" ]]; then
             # Auto-authorize if PR is from the repository owner
@@ -79,12 +79,12 @@ jobs:
     runs-on: ubuntu-20.04
     permissions:
       contents: read
-    
+
     environment: ${{ needs.check_authorization.outputs.is_authorized == 'true' && 'production' || 'no-secrets' }}
-    
+
     env:
       BUILDBUDDY_API_KEY: ${{ needs.check_authorization.outputs.is_authorized == 'true' && secrets.BUILDBUDDY_API_KEY || 'dummy-value-for-unauthorized-builds' }}
-      
+
     steps:
       - name: Log security context
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,56 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  check_authorization:
+    runs-on: ubuntu-20.04
+    permissions:
+      contents: read
+      pull-requests: read  # Needed to check PR labels
+
+    outputs:
+      is_authorized: ${{ steps.check.outputs.is_authorized }}
+
+    steps:
+      - name: Check authorization
+        id: check
+        run: |
+          # For push to main or workflow_dispatch, always authorize
+          if [[ "${{ github.event_name }}" == "push" || "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            echo "is_authorized=true" >> $GITHUB_OUTPUT
+            echo "Authorized: push or workflow_dispatch event"
+            exit 0
+          fi
+          
+          # For PRs, check various authorization criteria
+          if [[ "${{ github.event_name }}" == "pull_request_target" ]]; then
+            # Auto-authorize if PR is from the repository owner
+            if [[ "${{ github.event.pull_request.head.repo.owner.login }}" == "${{ github.repository_owner }}" ]]; then
+              echo "is_authorized=true" >> $GITHUB_OUTPUT
+              echo "Authorized: PR from repository owner"
+              exit 0
+            fi
+            
+            # Auto-authorize if PR is from a repository member/collaborator
+            if [[ "${{ github.event.pull_request.author_association }}" == "OWNER" || 
+                  "${{ github.event.pull_request.author_association }}" == "MEMBER" || 
+                  "${{ github.event.pull_request.author_association }}" == "COLLABORATOR" ]]; then
+              echo "is_authorized=true" >> $GITHUB_OUTPUT
+              echo "Authorized: PR from repository member/collaborator"
+              exit 0
+            fi
+            
+            # Check for the authorized-secrets label for external contributors
+            if [[ "${{ contains(github.event.pull_request.labels.*.name, 'authorized-secrets') }}" == "true" ]]; then
+              echo "is_authorized=true" >> $GITHUB_OUTPUT
+              echo "Authorized: PR with authorized-secrets label"
+              exit 0
+            fi
+            
+            # Not authorized
+            echo "is_authorized=false" >> $GITHUB_OUTPUT
+            echo "Not authorized: PR from external contributor without proper authorization"
+          fi
+
   build:
     runs-on: ubuntu-20.04
 


### PR DESCRIPTION
Add some safety checks to run CI for untrusted code while giving access to secrets.

**Resources:**

- https://stackoverflow.com/questions/76952023/how-to-make-github-actions-safely-access-secrets-for-prs-created-from-forks 
 
- https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/
- https://securitylab.github.com/resources/github-actions-untrusted-input/
- https://securitylab.github.com/resources/github-actions-building-blocks/
- https://securitylab.github.com/resources/github-actions-new-patterns-and-mitigations/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Enhanced the build process with tighter security and validation checks.
  - Improved controls for managing contributions to ensure a safer and more reliable user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->