### PR TITLE
fix: bazel in bazel for tests

### DIFF
--- a/src/it/java/org/antlr/bazel/Command.java
+++ b/src/it/java/org/antlr/bazel/Command.java
@@ -62,6 +62,16 @@ class Command {
     }
 
     /**
+     * Gets the bazel command to execute, respecting the BAZEL environment variable.
+     * 
+     * @return the bazel command path or "bazel" if not set.
+     */
+    private static String getBazelCommand() {
+        String bazelPath = System.getenv("BAZEL");
+        return bazelPath != null ? bazelPath : "bazel";
+    }
+
+    /**
      * Builds the specified target with additional flags.
      * 
      * @param flags Additional flags to pass to the bazel build command.
@@ -70,7 +80,7 @@ class Command {
      */
     public Command build(String... flags) throws Exception {
         List<String> command = new ArrayList<>();
-        command.add("bazel");
+        command.add(getBazelCommand());
         command.add("build");
         command.add("--jobs");
         command.add("2");

--- a/src/it/java/org/antlr/bazel/TestWorkspace.java
+++ b/src/it/java/org/antlr/bazel/TestWorkspace.java
@@ -148,6 +148,16 @@ class TestWorkspace
     }
 
     /**
+     * Gets the bazel command to execute, respecting the BAZEL environment variable.
+     * 
+     * @return the bazel command path or "bazel" if not set.
+     */
+    private static String getBazelCommand() {
+        String bazelPath = System.getenv("BAZEL");
+        return bazelPath != null ? bazelPath : "bazel";
+    }
+
+    /**
      * Retrieves a Bazel information path by executing a bazel info command.
      * This is used to get various Bazel-specific paths like bazel-bin.
      *
@@ -158,7 +168,7 @@ class TestWorkspace
     public Path path(String key) throws Exception
     {
         // Execute bazel info to get information about paths
-        Process p = new ProcessBuilder().command("bazel", "info", key)
+        Process p = new ProcessBuilder().command(getBazelCommand(), "info", key)
                 .redirectErrorStream(true)
                 .directory(root.toFile())
                 .start();


### PR DESCRIPTION
For systems where `bazel` does not exist in the `PATH` (e.g. alias to `bazelisk`), Integration Tests fail. This change makes the tests look for a `BAZEL` environment variable that tells the path of the executable to be considered. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for overriding the default Bazel executable by setting the BAZEL environment variable. This allows users to specify a custom Bazel command when running builds or tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->