### PR TITLE
fix: use jdk11 as the default_java_toolchain

### DIFF
--- a/.debug.bazelrc
+++ b/.debug.bazelrc
@@ -1,0 +1,1 @@
+common --toolchain_resolution_debug=@bazel_tools//tools/jdk:runtime_toolchain_type

--- a/.java.bazelrc
+++ b/.java.bazelrc
@@ -1,5 +1,6 @@
-build --java_language_version=11
-build --java_runtime_version=remotejdk_11
-build --tool_java_language_version=11
-build --tool_java_runtime_version=remotejdk_11
-build --javacopt="--release 11"
+common --java_language_version=11
+common --java_runtime_version=remotejdk_11
+common --tool_java_language_version=11
+common --tool_java_runtime_version=remotejdk_11
+common --java_header_compilation=false
+common --javacopt="--release 11"

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,5 +1,22 @@
+load("@rules_java//toolchains:default_java_toolchain.bzl", "default_java_toolchain")
+
 filegroup(
     name = "srcs",
     srcs = ["WORKSPACE.bazel"],
     visibility = ["//visibility:public"],
+)
+
+# To discover other available remote JDKs from @rules_java for future reference (e.g., for updates),
+# you can use a query like: bazel query 'filter(".*remote.*jdk.*", @rules_java//toolchains:all)'
+default_java_toolchain(
+    name = "default_remotejdk_11_toolchain_impl",
+    java_runtime = "@rules_java//toolchains:remote_jdk11",
+    source_version = "11",
+    target_version = "11",
+)
+
+toolchain(
+    name = "default_remotejdk_11_toolchain",
+    toolchain = ":default_remotejdk_11_toolchain_impl",
+    toolchain_type = "@bazel_tools//tools/jdk:toolchain_type",
 )

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -14,6 +14,10 @@ load("@rules_java//java:repositories.bzl", "rules_java_dependencies", "rules_jav
 
 rules_java_dependencies()
 
+# https://github.com/bazelbuild/bazel/issues/19934
+# https://github.com/bazelbuild/rules_java/issues/148
+register_toolchains("//:default_remotejdk_11_toolchain")
+
 rules_java_toolchains()
 
 http_archive(


### PR DESCRIPTION
- https://github.com/bazelbuild/bazel/issues/19934
- https://github.com/bazelbuild/rules_java/issues/148

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated Java toolchain configuration to use JDK 11 for builds.
  - Registered the new JDK 11 toolchain for improved Java build compatibility.
  - Enhanced build configuration with detailed toolchain resolution debugging.
  - Broadened Java-related build settings for more consistent application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->