### PR TITLE
refactor: use Guava's `EqualsTester` for equals test

### DIFF
--- a/antlr/repositories.bzl
+++ b/antlr/repositories.bzl
@@ -675,6 +675,12 @@ def rules_antlr_test_dependencies(repository = _MAVEN_CENTRAL):
             "version": "33.4.8-jre",
             "sha256": "f3d7f57f67fd622f4d468dfdd692b3a5e3909246c28017ac3263405f0fe617ed",
         },
+        "guava_testlib": {
+            "group": "com.google.guava",
+            "artifact": "guava-testlib",
+            "version": "33.4.8-jre",
+            "sha256": "a58a38746f97e02ae3d067b74a25ad2b136650227baa7124ce03fa3bce4e8576",
+        },
     }, repository)
 
 def _maven_jars(dependencies, repository = _MAVEN_CENTRAL):

--- a/src/test/java/org/antlr/bazel/BUILD.bazel
+++ b/src/test/java/org/antlr/bazel/BUILD.bazel
@@ -14,6 +14,7 @@ java_library(
     deps = [
         "//src/main/java/org/antlr/bazel",
         "@guava//jar",
+        "@guava_testlib//jar",
         "@jimfs//jar",
         "@junit//jar",
     ],

--- a/src/test/java/org/antlr/bazel/GrammarTest.java
+++ b/src/test/java/org/antlr/bazel/GrammarTest.java
@@ -13,12 +13,12 @@ import java.util.List;
 
 import com.google.common.jimfs.Configuration;
 import com.google.common.jimfs.Jimfs;
+import com.google.common.testing.EqualsTester;
 
 import static org.antlr.bazel.Language.*;
 import static org.antlr.bazel.Version.*;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
@@ -72,14 +72,16 @@ public class GrammarTest
     {
         Grammar g1 = grammar(V4,
                 path("examples/antlr4/InheritSameFolder/src/main/antlr4/G1.g4"));
-        assertEquals(g1, g1);
-        assertEquals(
-                grammar(V4, path("examples/antlr4/InheritSameFolder/src/main/antlr4/G3.g4")),
-                grammar(V4, path("examples/antlr4/InheritSameFolder/src/main/antlr4/G3.g4")));
-        assertNotEquals(g1,
-                grammar(V4, path("examples/antlr4/InheritSameFolder/src/main/antlr4/G2.g4")));
-        assertNotEquals(g1, null);
-        assertNotEquals(g1, new String());
+        Grammar g3a = grammar(V4, path("examples/antlr4/InheritSameFolder/src/main/antlr4/G3.g4"));
+        Grammar g3b = grammar(V4, path("examples/antlr4/InheritSameFolder/src/main/antlr4/G3.g4"));
+        Grammar g2 = grammar(V4, path("examples/antlr4/InheritSameFolder/src/main/antlr4/G2.g4"));
+        
+        new EqualsTester()
+                .addEqualityGroup(g1)
+                .addEqualityGroup(g3a, g3b)
+                .addEqualityGroup(g2)
+                .addEqualityGroup("different type")
+                .testEquals();
     }
 
 

--- a/src/test/java/org/antlr/bazel/NamespaceTest.java
+++ b/src/test/java/org/antlr/bazel/NamespaceTest.java
@@ -2,6 +2,8 @@ package org.antlr.bazel;
 
 import java.nio.file.Paths;
 
+import com.google.common.testing.EqualsTester;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -21,12 +23,17 @@ public class NamespaceTest
     @Test
     public void equals()
     {
-        Namespace namespace = Namespace.of("a");
-        assertTrue(Namespace.of("").equals(Namespace.of("")));
-        assertTrue(namespace.equals(namespace));
-        assertFalse(Namespace.of("").equals(Namespace.of("a")));
-        assertFalse(Namespace.of("").equals(null));
-        assertFalse(Namespace.of("").equals(""));
+        Namespace empty1 = Namespace.of("");
+        Namespace empty2 = Namespace.of("");
+        Namespace namespaceA = Namespace.of("a");
+        Namespace namespaceB = Namespace.of("b");
+        
+        new EqualsTester()
+                .addEqualityGroup(empty1, empty2)
+                .addEqualityGroup(namespaceA)
+                .addEqualityGroup(namespaceB)
+                .addEqualityGroup("different type")
+                .testEquals();
     }
 
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated test dependencies to include Guava TestLib.
- **Tests**
	- Refactored equality tests in GrammarTest and NamespaceTest to use Guava's EqualsTester for improved clarity and coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->