### PR TITLE
Remove stray markdown code block opener

### DIFF
--- a/.agents/README.md
+++ b/.agents/README.md
@@ -97,7 +97,7 @@ sudo apt-get install yq tmux gh
 
 # Arch Linux
 sudo pacman -S yq tmux github-cli
-```bash
+```
 
 ## Usage
 


### PR DESCRIPTION
Corrected an incorrectly typed markdown code block delimiter in `.agents/README.md`.
An orphaned ` ```bash ` was causing invalid markdown syntax and breaking document formatting; it was corrected to a proper closing delimiter to resolve this.

---

[Open in Web](https://www.cursor.com/agents?id=bc-58842c1d-142a-4ca6-bc13-bac7d0de88b0) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-58842c1d-142a-4ca6-bc13-bac7d0de88b0)