### PR TITLE
Update test to only check active worktrees

### DIFF
--- a/.agents/test-workflow.sh
+++ b/.agents/test-workflow.sh
@@ -98,7 +98,7 @@ test_worktree_setup() {
             "true"
         
         run_test "All expected worktrees created" \
-            "[ -d \"$WORKTREE_DIR/npe-env\" ] && [ -d \"$WORKTREE_DIR/bazel-dict\" ] && [ -d \"$WORKTREE_DIR/resource-process\" ]" \
+            "[ -d \"$WORKTREE_DIR/npe-env\" ] && [ -d \"$WORKTREE_DIR/npe-builder\" ] && [ -d \"$WORKTREE_DIR/resource-process\" ]" \
             "true"
         
         run_test "TODO.md copied to worktrees" \

--- a/.agents/workflow-test.log
+++ b/.agents/workflow-test.log
@@ -1,0 +1,1 @@
+=== rules_antlr Parallel Workflow Test Suite Thu Jul 24 07:59:40 AM UTC 2025 ===


### PR DESCRIPTION
Update worktree creation test to check for active TODOs only.

The "All expected worktrees created" test in `.agents/test-workflow.sh` was failing because it checked for the `bazel-dict` worktree. This worktree corresponds to `TODO-005`, which is marked as cancelled in `todos.yaml`. Since the `setup-worktrees.sh` script correctly skips creating worktrees for cancelled TODOs, `bazel-dict` was never created, causing the test to always fail. This PR updates the test to check for `npe-builder` (corresponding to an active TODO) instead of `bazel-dict`.

---

[Open in Web](https://www.cursor.com/agents?id=bc-a1375142-c3ea-466b-a4b0-deaea07bfd6b) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-a1375142-c3ea-466b-a4b0-deaea07bfd6b)